### PR TITLE
Change the scope field from GLOBAL to DOMAIN

### DIFF
--- a/src/spaceone/monitoring/conf/default_escalation_policy.py
+++ b/src/spaceone/monitoring/conf/default_escalation_policy.py
@@ -9,5 +9,5 @@ DEFAULT_ESCALATION_POLICY = {
     ],
     'repeat_count': 0,
     'finish_condition': 'ACKNOWLEDGED',
-    'scope': 'GLOBAL'
+    'scope': 'DOMAIN'
 }

--- a/src/spaceone/monitoring/manager/escalation_policy_manager.py
+++ b/src/spaceone/monitoring/manager/escalation_policy_manager.py
@@ -49,7 +49,7 @@ class EscalationPolicyManager(BaseManager):
 
     def set_default_escalation_policy(self, params, escalation_policy_vo):
         global_escalation_policy_vos = self.escalation_policy_model.filter(domain_id=params['domain_id'],
-                                                                           scope='GLOBAL')
+                                                                           scope='DOMAIN')
 
         for global_escalation_policy_vo in global_escalation_policy_vos:
             global_escalation_policy_vo.update({'is_default': False})

--- a/src/spaceone/monitoring/model/escalation_policy_model.py
+++ b/src/spaceone/monitoring/model/escalation_policy_model.py
@@ -19,7 +19,7 @@ class EscalationPolicy(MongoModel):
     repeat_count = IntField(default=0)
     finish_condition = StringField(max_length=20, default='ACKNOWLEDGED', choices=('ACKNOWLEDGED', 'RESOLVED'))
     tags = DictField()
-    scope = StringField(max_length=20, choices=('GLOBAL', 'PROJECT'))
+    scope = StringField(max_length=20, choices=('DOMAIN', 'PROJECT'))
     project_id = StringField(max_length=40, default=None, null=True)
     domain_id = StringField(max_length=40)
     created_at = DateTimeField(auto_now_add=True)

--- a/src/spaceone/monitoring/service/escalation_policy_service.py
+++ b/src/spaceone/monitoring/service/escalation_policy_service.py
@@ -54,7 +54,7 @@ class EscalationPolicyService(BaseService):
             identity_mgr.get_project(project_id, domain_id)
             params['scope'] = 'PROJECT'
         else:
-            params['scope'] = 'GLOBAL'
+            params['scope'] = 'DOMAIN'
 
         return self.escalation_policy_mgr.create_escalation_policy(params)
 
@@ -108,7 +108,7 @@ class EscalationPolicyService(BaseService):
         escalation_policy_vo: EscalationPolicy = self.escalation_policy_mgr.get_escalation_policy(escalation_policy_id,
                                                                                                   domain_id)
 
-        if escalation_policy_vo.scope != 'GLOBAL':
+        if escalation_policy_vo.scope != 'DOMAIN':
             raise ERROR_INVALID_ESCALATION_POLICY_SCOPE(escalation_policy_id=escalation_policy_id)
 
         if escalation_policy_vo.is_default:


### PR DESCRIPTION
Signed-off-by: Seolmin Kwon <seolmin@megazone.com>

### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [X] Refactor
- [ ] etc

### Description
I changed it because `DOMAIN` is more suitable than `GLOBAL` according to spaceone's permission system.

### Known issue
* #2 