### PR TITLE
add min_value option in escalation policy

### DIFF
--- a/src/spaceone/monitoring/model/escalation_policy_model.py
+++ b/src/spaceone/monitoring/model/escalation_policy_model.py
@@ -5,7 +5,7 @@ from spaceone.core.model.mongo_model import MongoModel
 
 class EscalationRule(EmbeddedDocument):
     notification_level = StringField(max_length=20, default='ALL')
-    escalate_minutes = IntField(default=0)
+    escalate_minutes = IntField(default=0, min_value=0)
 
     def to_dict(self):
         return self.to_mongo()
@@ -16,7 +16,7 @@ class EscalationPolicy(MongoModel):
     name = StringField(max_length=255, unique_with='domain_id')
     is_default = BooleanField(default=False)
     rules = ListField(EmbeddedDocumentField(EscalationRule))
-    repeat_count = IntField(default=0)
+    repeat_count = IntField(default=0, min_value=0)
     finish_condition = StringField(max_length=20, default='ACKNOWLEDGED', choices=('ACKNOWLEDGED', 'RESOLVED'))
     tags = DictField()
     scope = StringField(max_length=20, choices=('GLOBAL', 'PROJECT'))


### PR DESCRIPTION
Signed-off-by: seolmin <seolmin@megazone.com>

### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [x] Refactor
- [ ] etc

### Description
Measures were taken to prevent negative numbers from entering through min_value options of IntField of mongo model.

### Known issue
* #17 