### PR TITLE
fix: remove trasaction variable used when initializing in connectors

### DIFF
--- a/src/spaceone/monitoring/connector/datasource_plugin_connector.py
+++ b/src/spaceone/monitoring/connector/datasource_plugin_connector.py
@@ -11,8 +11,8 @@ _LOGGER = logging.getLogger(__name__)
 
 class DataSourcePluginConnector(BaseConnector):
 
-    def __init__(self, transaction, config):
-        super().__init__(transaction, config)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.client = None
 
     def initialize(self, endpoint):

--- a/src/spaceone/monitoring/connector/webhook_plugin_connector.py
+++ b/src/spaceone/monitoring/connector/webhook_plugin_connector.py
@@ -14,8 +14,8 @@ _LOGGER = logging.getLogger(__name__)
 
 class WebhookPluginConnector(BaseConnector):
 
-    def __init__(self, transaction, config):
-        super().__init__(transaction, config)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.client = None
 
     def initialize(self, endpoint):


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [x] Refactor
- [ ] etc

### Description
* As the transaction structure of the core framework changes, the transaction variable of the dependent microservice is removed.