### PR TITLE
Added FastAPI Body to handle request body, causing an error.

### DIFF
--- a/src/spaceone/monitoring/interface/rest/v1/event.py
+++ b/src/spaceone/monitoring/interface/rest/v1/event.py
@@ -1,5 +1,5 @@
 import logging
-from fastapi import Request, Body
+from fastapi import Request
 from fastapi_utils.inferring_router import InferringRouter
 from fastapi_utils.cbv import cbv
 from spaceone.core.fastapi.api import BaseAPI
@@ -13,9 +13,7 @@ router = InferringRouter()
 @cbv(router)
 class Event(BaseAPI):
     @router.post("/webhook/{webhook_id}/{access_key}/events")
-    async def create_event(
-        self, access_key: str, webhook_id: str, request: Request, data: dict = Body()
-    ):
+    async def create_event(self, access_key: str, webhook_id: str, request: Request):
         params, metadata = await self.parse_request(request)
 
         event_service: EventService = self.locator.get_service("EventService")


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
Added `data: dict = Body()` to the `create_event` method to explicitly handle the request body as a dictionary. This change was intended to ensure that the incoming JSON payload is correctly parsed and accessible within the method. However, this modification caused an error, likely due to a conflict with the existing request parsing logic or parameter handling within the method.

To avoid this issue, use `Body(default={})` without the `request` parameter. If you want to use `request`, remove `Body(default={})`.

### Known issue
Using `request` and FastAPI's `Body()` together in the `create_event` method causes an error when the POST request has no body. 
